### PR TITLE
Use a static reference to a location where possible

### DIFF
--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -387,7 +387,7 @@ impl BundleInfo {
         table_row: TableRow,
         change_tick: Tick,
         bundle: T,
-        caller: core::panic::Location<'static>,
+        caller: &'static core::panic::Location<'static>,
     ) {
         // NOTE: get_components calls this closure on each component in "bundle order".
         // bundle_info.component_ids are also in "bundle order"
@@ -648,7 +648,7 @@ impl<'w> BundleInserter<'w> {
         let add_bundle = self.add_bundle.as_ref();
         let table = self.table.as_mut();
         let archetype = self.archetype.as_mut();
-        let caller = *core::panic::Location::caller();
+        let caller = core::panic::Location::caller();
 
         let (new_archetype, new_location) = match &mut self.result {
             InsertBundleResult::SameArchetype => {
@@ -887,7 +887,7 @@ impl<'w> BundleSpawner<'w> {
         &mut self,
         entity: Entity,
         bundle: T,
-        caller: core::panic::Location<'static>,
+        caller: &'static core::panic::Location<'static>,
     ) -> EntityLocation {
         let table = self.table.as_mut();
         let archetype = self.archetype.as_mut();
@@ -938,7 +938,7 @@ impl<'w> BundleSpawner<'w> {
     pub unsafe fn spawn<T: Bundle>(
         &mut self,
         bundle: T,
-        caller: core::panic::Location<'static>,
+        caller: &'static core::panic::Location<'static>,
     ) -> Entity {
         let entity = self.entities().alloc();
         // SAFETY: entity is allocated (but non-existent), `T` matches this BundleInfo's type

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -65,7 +65,7 @@ pub trait DetectChanges {
     fn last_changed(&self) -> Tick;
 
     /// The location that last caused this to change.
-    fn changed_by(&self) -> core::panic::Location<'static>;
+    fn changed_by(&self) -> &'static core::panic::Location<'static>;
 }
 
 /// Types that implement reliable change detection.
@@ -286,7 +286,7 @@ macro_rules! change_detection_impl {
             }
 
             #[inline]
-            fn changed_by(&self) -> core::panic::Location<'static> {
+            fn changed_by(&self) -> &'static core::panic::Location<'static> {
                 *self.caller
             }
         }
@@ -318,14 +318,14 @@ macro_rules! change_detection_mut_impl {
             #[track_caller]
             fn set_changed(&mut self) {
                 *self.ticks.changed = self.ticks.this_run;
-                *self.caller = *core::panic::Location::caller();
+                *self.caller = core::panic::Location::caller();
             }
 
             #[inline]
             #[track_caller]
             fn set_last_changed(&mut self, last_changed: Tick) {
                 *self.ticks.changed = last_changed;
-                *self.caller = *core::panic::Location::caller();
+                *self.caller = core::panic::Location::caller();
             }
 
             #[inline]
@@ -339,7 +339,7 @@ macro_rules! change_detection_mut_impl {
             #[track_caller]
             fn deref_mut(&mut self) -> &mut Self::Target {
                 self.set_changed();
-                *self.caller = *core::panic::Location::caller();
+                *self.caller = core::panic::Location::caller();
                 self.value
             }
         }
@@ -518,7 +518,7 @@ impl<'w> From<TicksMut<'w>> for Ticks<'w> {
 pub struct Res<'w, T: ?Sized + Resource> {
     pub(crate) value: &'w T,
     pub(crate) ticks: Ticks<'w>,
-    pub(crate) caller: &'w core::panic::Location<'static>,
+    pub(crate) caller: &'w &'static core::panic::Location<'static>,
 }
 
 impl<'w, T: Resource> Res<'w, T> {
@@ -581,7 +581,7 @@ impl_debug!(Res<'w, T>, Resource);
 pub struct ResMut<'w, T: ?Sized + Resource> {
     pub(crate) value: &'w mut T,
     pub(crate) ticks: TicksMut<'w>,
-    pub(crate) caller: &'w mut core::panic::Location<'static>,
+    pub(crate) caller: &'w mut &'static core::panic::Location<'static>,
 }
 
 impl<'w, 'a, T: Resource> IntoIterator for &'a ResMut<'w, T>
@@ -641,7 +641,7 @@ impl<'w, T: Resource> From<ResMut<'w, T>> for Mut<'w, T> {
 pub struct NonSendMut<'w, T: ?Sized + 'static> {
     pub(crate) value: &'w mut T,
     pub(crate) ticks: TicksMut<'w>,
-    pub(crate) caller: &'w mut core::panic::Location<'static>,
+    pub(crate) caller: &'w mut &'static core::panic::Location<'static>,
 }
 
 change_detection_impl!(NonSendMut<'w, T>, T,);
@@ -688,7 +688,7 @@ impl<'w, T: 'static> From<NonSendMut<'w, T>> for Mut<'w, T> {
 pub struct Ref<'w, T: ?Sized> {
     pub(crate) value: &'w T,
     pub(crate) ticks: Ticks<'w>,
-    pub(crate) caller: &'w core::panic::Location<'static>,
+    pub(crate) caller: &'w &'static core::panic::Location<'static>,
 }
 
 impl<'w, T: ?Sized> Ref<'w, T> {
@@ -726,7 +726,7 @@ impl<'w, T: ?Sized> Ref<'w, T> {
         changed: &'w Tick,
         last_run: Tick,
         this_run: Tick,
-        caller: &'w core::panic::Location<'static>,
+        caller: &'w &'static core::panic::Location<'static>,
     ) -> Ref<'w, T> {
         Ref {
             value,
@@ -818,7 +818,7 @@ impl_debug!(Ref<'w, T>,);
 pub struct Mut<'w, T: ?Sized> {
     pub(crate) value: &'w mut T,
     pub(crate) ticks: TicksMut<'w>,
-    pub(crate) caller: &'w mut core::panic::Location<'static>,
+    pub(crate) caller: &'w mut &'static core::panic::Location<'static>,
 }
 
 impl<'w, T: ?Sized> Mut<'w, T> {
@@ -843,7 +843,7 @@ impl<'w, T: ?Sized> Mut<'w, T> {
         last_changed: &'w mut Tick,
         last_run: Tick,
         this_run: Tick,
-        caller: &'w mut core::panic::Location<'static>,
+        caller: &'w mut &'static core::panic::Location<'static>,
     ) -> Self {
         Self {
             value,
@@ -909,7 +909,7 @@ impl_debug!(Mut<'w, T>,);
 pub struct MutUntyped<'w> {
     pub(crate) value: PtrMut<'w>,
     pub(crate) ticks: TicksMut<'w>,
-    pub(crate) caller: &'w mut core::panic::Location<'static>,
+    pub(crate) caller: &'w mut &'static core::panic::Location<'static>,
 }
 
 impl<'w> MutUntyped<'w> {
@@ -1024,7 +1024,7 @@ impl<'w> DetectChanges for MutUntyped<'w> {
     }
 
     #[inline]
-    fn changed_by(&self) -> core::panic::Location<'static> {
+    fn changed_by(&self) -> &'static core::panic::Location<'static> {
         *self.caller
     }
 }
@@ -1036,14 +1036,14 @@ impl<'w> DetectChangesMut for MutUntyped<'w> {
     #[track_caller]
     fn set_changed(&mut self) {
         *self.ticks.changed = self.ticks.this_run;
-        *self.caller = *core::panic::Location::caller();
+        *self.caller = core::panic::Location::caller();
     }
 
     #[inline]
     #[track_caller]
     fn set_last_changed(&mut self, last_changed: Tick) {
         *self.ticks.changed = last_changed;
-        *self.caller = *core::panic::Location::caller();
+        *self.caller = core::panic::Location::caller();
     }
 
     #[inline]

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -287,7 +287,7 @@ macro_rules! change_detection_impl {
 
             #[inline]
             fn changed_by(&self) -> &'static core::panic::Location<'static> {
-                *self.caller
+                self.caller
             }
         }
 
@@ -518,7 +518,7 @@ impl<'w> From<TicksMut<'w>> for Ticks<'w> {
 pub struct Res<'w, T: ?Sized + Resource> {
     pub(crate) value: &'w T,
     pub(crate) ticks: Ticks<'w>,
-    pub(crate) caller: &'w &'static core::panic::Location<'static>,
+    pub(crate) caller: &'static core::panic::Location<'static>,
 }
 
 impl<'w, T: Resource> Res<'w, T> {
@@ -688,7 +688,7 @@ impl<'w, T: 'static> From<NonSendMut<'w, T>> for Mut<'w, T> {
 pub struct Ref<'w, T: ?Sized> {
     pub(crate) value: &'w T,
     pub(crate) ticks: Ticks<'w>,
-    pub(crate) caller: &'w &'static core::panic::Location<'static>,
+    pub(crate) caller: &'static core::panic::Location<'static>,
 }
 
 impl<'w, T: ?Sized> Ref<'w, T> {
@@ -726,7 +726,7 @@ impl<'w, T: ?Sized> Ref<'w, T> {
         changed: &'w Tick,
         last_run: Tick,
         this_run: Tick,
-        caller: &'w &'static core::panic::Location<'static>,
+        caller: &'static core::panic::Location<'static>,
     ) -> Ref<'w, T> {
         Ref {
             value,

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1026,7 +1026,7 @@ pub struct RefFetch<'w, T> {
         ThinSlicePtr<'w, UnsafeCell<T>>,
         ThinSlicePtr<'w, UnsafeCell<Tick>>,
         ThinSlicePtr<'w, UnsafeCell<Tick>>,
-        ThinSlicePtr<'w, UnsafeCell<core::panic::Location<'static>>>,
+        ThinSlicePtr<'w, UnsafeCell<&'static core::panic::Location<'static>>>,
     )>,
     // T::STORAGE_TYPE = StorageType::SparseSet
     sparse_set: Option<&'w ComponentSparseSet>,
@@ -1215,7 +1215,7 @@ pub struct WriteFetch<'w, T> {
         ThinSlicePtr<'w, UnsafeCell<T>>,
         ThinSlicePtr<'w, UnsafeCell<Tick>>,
         ThinSlicePtr<'w, UnsafeCell<Tick>>,
-        ThinSlicePtr<'w, UnsafeCell<core::panic::Location<'static>>>,
+        ThinSlicePtr<'w, UnsafeCell<&'static core::panic::Location<'static>>>,
     )>,
     // T::STORAGE_TYPE = StorageType::SparseSet
     sparse_set: Option<&'w ComponentSparseSet>,

--- a/crates/bevy_ecs/src/storage/resource.rs
+++ b/crates/bevy_ecs/src/storage/resource.rs
@@ -17,7 +17,7 @@ pub struct ResourceData<const SEND: bool> {
     type_name: String,
     id: ArchetypeComponentId,
     origin_thread_id: Option<ThreadId>,
-    caller: UnsafeCell<core::panic::Location<'static>>,
+    caller: UnsafeCell<&'static core::panic::Location<'static>>,
 }
 
 impl<const SEND: bool> Drop for ResourceData<SEND> {
@@ -115,7 +115,7 @@ impl<const SEND: bool> ResourceData<SEND> {
     ) -> Option<(
         Ptr<'_>,
         TickCells<'_>,
-        &UnsafeCell<core::panic::Location<'static>>,
+        &UnsafeCell<&'static core::panic::Location<'static>>,
     )> {
         self.is_present().then(|| {
             self.validate_access();
@@ -222,7 +222,7 @@ impl<const SEND: bool> ResourceData<SEND> {
     ) -> Option<(
         OwningPtr<'_>,
         ComponentTicks,
-        core::panic::Location<'static>,
+        &'static core::panic::Location<'static>,
     )> {
         if !self.is_present() {
             return None;
@@ -354,7 +354,7 @@ impl<const SEND: bool> Resources<SEND> {
                 type_name: String::from(component_info.name()),
                 id: f(),
                 origin_thread_id: None,
-                caller: UnsafeCell::new(*core::panic::Location::caller())
+                caller: UnsafeCell::new(core::panic::Location::caller())
             }
         })
     }

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -169,7 +169,7 @@ impl ComponentSparseSet {
         entity: Entity,
         value: OwningPtr<'_>,
         change_tick: Tick,
-        caller: core::panic::Location<'static>,
+        caller: &'static core::panic::Location<'static>,
     ) {
         if let Some(&dense_index) = self.sparse.get(entity.index()) {
             #[cfg(debug_assertions)]
@@ -230,7 +230,7 @@ impl ComponentSparseSet {
     ) -> Option<(
         Ptr<'_>,
         TickCells<'_>,
-        &UnsafeCell<core::panic::Location<'static>>,
+        &UnsafeCell<&'static core::panic::Location<'static>>,
     )> {
         let dense_index = *self.sparse.get(entity.index())?;
         #[cfg(debug_assertions)]

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -960,7 +960,7 @@ impl World {
             let mut bundle_spawner = BundleSpawner::new::<B>(self, change_tick);
             // SAFETY: bundle's type matches `bundle_info`, entity is allocated but non-existent
             unsafe {
-                bundle_spawner.spawn_non_existent(entity, bundle, *core::panic::Location::caller())
+                bundle_spawner.spawn_non_existent(entity, bundle, core::panic::Location::caller())
             }
         };
 
@@ -1801,7 +1801,7 @@ impl World {
                             spawner.spawn_non_existent(
                                 entity,
                                 bundle,
-                                *core::panic::Location::caller(),
+                                core::panic::Location::caller(),
                             )
                         };
                     } else {
@@ -1813,7 +1813,7 @@ impl World {
                             spawner.spawn_non_existent(
                                 entity,
                                 bundle,
-                                *core::panic::Location::caller(),
+                                core::panic::Location::caller(),
                             )
                         };
                         spawn_or_insert = SpawnOrInsert::Spawn(spawner);

--- a/crates/bevy_ecs/src/world/spawn_batch.rs
+++ b/crates/bevy_ecs/src/world/spawn_batch.rs
@@ -16,7 +16,7 @@ where
 {
     inner: I,
     spawner: BundleSpawner<'w>,
-    caller: core::panic::Location<'static>,
+    caller: &'static core::panic::Location<'static>,
 }
 
 impl<'w, I> SpawnBatchIter<'w, I>
@@ -43,7 +43,7 @@ where
         Self {
             inner: iter,
             spawner,
-            caller: *core::panic::Location::caller(),
+            caller: core::panic::Location::caller(),
         }
     }
 }

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -541,7 +541,7 @@ impl<'w> UnsafeWorldCell<'w> {
     ) -> Option<(
         Ptr<'w>,
         TickCells<'w>,
-        &'w UnsafeCell<core::panic::Location<'static>>,
+        &'w UnsafeCell<&'static core::panic::Location<'static>>,
     )> {
         // SAFETY:
         // - caller ensures there is no `&mut World`
@@ -569,7 +569,7 @@ impl<'w> UnsafeWorldCell<'w> {
     ) -> Option<(
         Ptr<'w>,
         TickCells<'w>,
-        &'w UnsafeCell<core::panic::Location<'static>>,
+        &'w UnsafeCell<&'static core::panic::Location<'static>>,
     )> {
         // SAFETY:
         // - caller ensures there is no `&mut World`
@@ -983,7 +983,7 @@ unsafe fn get_component_and_ticks(
 ) -> Option<(
     Ptr<'_>,
     TickCells<'_>,
-    &UnsafeCell<core::panic::Location<'static>>,
+    &UnsafeCell<&'static core::panic::Location<'static>>,
 )> {
     match storage_type {
         StorageType::Table => {


### PR DESCRIPTION
I decided to try implementing my suggestion about using static references instead of raw locations. Took me a while because life got in the way. Note that `Location`s are 24 bytes (`str`s are unsized so references to them alone take 16 bytes) so this should shrink the `callers` vec by 2/3ds.