### PR TITLE
#14034 improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -338,6 +338,9 @@ ios_simulator = ["bevy_internal/ios_simulator"]
 # Enable built in global state machines
 bevy_state = ["bevy_internal/bevy_state"]
 
+# Enables source location tracking for change detection, which can assist with debugging
+track_change_detection = ["bevy_internal/track_change_detection"]
+
 [dependencies]
 bevy_internal = { path = "crates/bevy_internal", version = "0.14.0-dev", default-features = false }
 

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -16,7 +16,7 @@ trace = []
 multi_threaded = ["bevy_tasks/multi_threaded", "arrayvec"]
 bevy_debug_stepping = []
 serialize = ["dep:serde"]
-change_detection_source = []
+track_change_detection = []
 
 [dependencies]
 bevy_ptr = { path = "../bevy_ptr", version = "0.14.0-dev" }

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -11,11 +11,12 @@ categories = ["game-engines", "data-structures"]
 rust-version = "1.77.0"
 
 [features]
+default = ["bevy_reflect"]
 trace = []
 multi_threaded = ["bevy_tasks/multi_threaded", "arrayvec"]
 bevy_debug_stepping = []
-default = ["bevy_reflect"]
 serialize = ["dep:serde"]
+change_detection_source = []
 
 [dependencies]
 bevy_ptr = { path = "../bevy_ptr", version = "0.14.0-dev" }

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -386,7 +386,7 @@ impl BundleInfo {
         table_row: TableRow,
         change_tick: Tick,
         bundle: T,
-        caller: Location<'static>,
+        caller: &'static Location<'static>,
     ) {
         // NOTE: get_components calls this closure on each component in "bundle order".
         // bundle_info.component_ids are also in "bundle order"
@@ -647,7 +647,7 @@ impl<'w> BundleInserter<'w> {
         let add_bundle = self.add_bundle.as_ref();
         let table = self.table.as_mut();
         let archetype = self.archetype.as_mut();
-        let caller = *Location::caller();
+        let caller = Location::caller();
 
         let (new_archetype, new_location) = match &mut self.result {
             InsertBundleResult::SameArchetype => {
@@ -886,7 +886,7 @@ impl<'w> BundleSpawner<'w> {
         &mut self,
         entity: Entity,
         bundle: T,
-        caller: Location<'static>,
+        caller: &'static Location<'static>,
     ) -> EntityLocation {
         let table = self.table.as_mut();
         let archetype = self.archetype.as_mut();
@@ -934,7 +934,11 @@ impl<'w> BundleSpawner<'w> {
     /// # Safety
     /// `T` must match this [`BundleInfo`]'s type
     #[inline]
-    pub unsafe fn spawn<T: Bundle>(&mut self, bundle: T, caller: Location<'static>) -> Entity {
+    pub unsafe fn spawn<T: Bundle>(
+        &mut self,
+        bundle: T,
+        caller: &'static Location<'static>,
+    ) -> Entity {
         let entity = self.entities().alloc();
         // SAFETY: entity is allocated (but non-existent), `T` matches this BundleInfo's type
         unsafe {

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -19,8 +19,7 @@ use crate::{
 };
 use bevy_ptr::{ConstNonNull, OwningPtr};
 use bevy_utils::all_tuples;
-use std::any::TypeId;
-use std::ptr::NonNull;
+use std::{any::TypeId, panic::Location, ptr::NonNull};
 
 /// The `Bundle` trait enables insertion and removal of [`Component`]s from an entity.
 ///
@@ -387,7 +386,7 @@ impl BundleInfo {
         table_row: TableRow,
         change_tick: Tick,
         bundle: T,
-        caller: core::panic::Location<'static>,
+        caller: Location<'static>,
     ) {
         // NOTE: get_components calls this closure on each component in "bundle order".
         // bundle_info.component_ids are also in "bundle order"
@@ -648,7 +647,7 @@ impl<'w> BundleInserter<'w> {
         let add_bundle = self.add_bundle.as_ref();
         let table = self.table.as_mut();
         let archetype = self.archetype.as_mut();
-        let caller = *core::panic::Location::caller();
+        let caller = *Location::caller();
 
         let (new_archetype, new_location) = match &mut self.result {
             InsertBundleResult::SameArchetype => {
@@ -887,7 +886,7 @@ impl<'w> BundleSpawner<'w> {
         &mut self,
         entity: Entity,
         bundle: T,
-        caller: core::panic::Location<'static>,
+        caller: Location<'static>,
     ) -> EntityLocation {
         let table = self.table.as_mut();
         let archetype = self.archetype.as_mut();
@@ -935,11 +934,7 @@ impl<'w> BundleSpawner<'w> {
     /// # Safety
     /// `T` must match this [`BundleInfo`]'s type
     #[inline]
-    pub unsafe fn spawn<T: Bundle>(
-        &mut self,
-        bundle: T,
-        caller: core::panic::Location<'static>,
-    ) -> Entity {
+    pub unsafe fn spawn<T: Bundle>(&mut self, bundle: T, caller: Location<'static>) -> Entity {
         let entity = self.entities().alloc();
         // SAFETY: entity is allocated (but non-existent), `T` matches this BundleInfo's type
         unsafe {

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -19,7 +19,9 @@ use crate::{
 };
 use bevy_ptr::{ConstNonNull, OwningPtr};
 use bevy_utils::all_tuples;
-use std::{any::TypeId, panic::Location, ptr::NonNull};
+#[cfg(feature = "track_change_detection")]
+use std::panic::Location;
+use std::{any::TypeId, ptr::NonNull};
 
 /// The `Bundle` trait enables insertion and removal of [`Component`]s from an entity.
 ///
@@ -386,7 +388,7 @@ impl BundleInfo {
         table_row: TableRow,
         change_tick: Tick,
         bundle: T,
-        caller: &'static Location<'static>,
+        #[cfg(feature = "track_change_detection")] caller: &'static Location<'static>,
     ) {
         // NOTE: get_components calls this closure on each component in "bundle order".
         // bundle_info.component_ids are also in "bundle order"
@@ -403,10 +405,22 @@ impl BundleInfo {
                     let status = unsafe { bundle_component_status.get_status(bundle_component) };
                     match status {
                         ComponentStatus::Added => {
-                            column.initialize(table_row, component_ptr, change_tick, caller);
+                            column.initialize(
+                                table_row,
+                                component_ptr,
+                                change_tick,
+                                #[cfg(feature = "track_change_detection")]
+                                caller,
+                            );
                         }
                         ComponentStatus::Mutated => {
-                            column.replace(table_row, component_ptr, change_tick, caller);
+                            column.replace(
+                                table_row,
+                                component_ptr,
+                                change_tick,
+                                #[cfg(feature = "track_change_detection")]
+                                caller,
+                            );
                         }
                     }
                 }
@@ -415,7 +429,13 @@ impl BundleInfo {
                         // SAFETY: If component_id is in self.component_ids, BundleInfo::new requires that
                         // a sparse set exists for the component.
                         unsafe { sparse_sets.get_mut(component_id).debug_checked_unwrap() };
-                    sparse_set.insert(entity, component_ptr, change_tick, caller);
+                    sparse_set.insert(
+                        entity,
+                        component_ptr,
+                        change_tick,
+                        #[cfg(feature = "track_change_detection")]
+                        caller,
+                    );
                 }
             }
             bundle_component += 1;
@@ -647,6 +667,7 @@ impl<'w> BundleInserter<'w> {
         let add_bundle = self.add_bundle.as_ref();
         let table = self.table.as_mut();
         let archetype = self.archetype.as_mut();
+        #[cfg(feature = "track_change_detection")]
         let caller = Location::caller();
 
         let (new_archetype, new_location) = match &mut self.result {
@@ -665,6 +686,7 @@ impl<'w> BundleInserter<'w> {
                     location.table_row,
                     self.change_tick,
                     bundle,
+                    #[cfg(feature = "track_change_detection")]
                     caller,
                 );
 
@@ -704,6 +726,7 @@ impl<'w> BundleInserter<'w> {
                     result.table_row,
                     self.change_tick,
                     bundle,
+                    #[cfg(feature = "track_change_detection")]
                     caller,
                 );
 
@@ -784,6 +807,7 @@ impl<'w> BundleInserter<'w> {
                     move_result.new_row,
                     self.change_tick,
                     bundle,
+                    #[cfg(feature = "track_change_detection")]
                     caller,
                 );
 
@@ -886,7 +910,7 @@ impl<'w> BundleSpawner<'w> {
         &mut self,
         entity: Entity,
         bundle: T,
-        caller: &'static Location<'static>,
+        #[cfg(feature = "track_change_detection")] caller: &'static Location<'static>,
     ) -> EntityLocation {
         let table = self.table.as_mut();
         let archetype = self.archetype.as_mut();
@@ -909,6 +933,7 @@ impl<'w> BundleSpawner<'w> {
                 table_row,
                 self.change_tick,
                 bundle,
+                #[cfg(feature = "track_change_detection")]
                 caller,
             );
             entities.set(entity.index(), location);
@@ -937,12 +962,17 @@ impl<'w> BundleSpawner<'w> {
     pub unsafe fn spawn<T: Bundle>(
         &mut self,
         bundle: T,
-        caller: &'static Location<'static>,
+        #[cfg(feature = "track_change_detection")] caller: &'static Location<'static>,
     ) -> Entity {
         let entity = self.entities().alloc();
         // SAFETY: entity is allocated (but non-existent), `T` matches this BundleInfo's type
         unsafe {
-            self.spawn_non_existent(entity, bundle, caller);
+            self.spawn_non_existent(
+                entity,
+                bundle,
+                #[cfg(feature = "track_change_detection")]
+                caller,
+            );
         }
         entity
     }

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use bevy_ptr::{ThinSlicePtr, UnsafeCellDeref};
 use bevy_utils::all_tuples;
-use std::{cell::UnsafeCell, marker::PhantomData};
+use std::{cell::UnsafeCell, marker::PhantomData, panic::Location};
 
 /// Types that can be fetched from a [`World`] using a [`Query`].
 ///
@@ -1026,7 +1026,7 @@ pub struct RefFetch<'w, T> {
         ThinSlicePtr<'w, UnsafeCell<T>>,
         ThinSlicePtr<'w, UnsafeCell<Tick>>,
         ThinSlicePtr<'w, UnsafeCell<Tick>>,
-        ThinSlicePtr<'w, UnsafeCell<core::panic::Location<'static>>>,
+        ThinSlicePtr<'w, UnsafeCell<Location<'static>>>,
     )>,
     // T::STORAGE_TYPE = StorageType::SparseSet
     sparse_set: Option<&'w ComponentSparseSet>,
@@ -1215,7 +1215,7 @@ pub struct WriteFetch<'w, T> {
         ThinSlicePtr<'w, UnsafeCell<T>>,
         ThinSlicePtr<'w, UnsafeCell<Tick>>,
         ThinSlicePtr<'w, UnsafeCell<Tick>>,
-        ThinSlicePtr<'w, UnsafeCell<core::panic::Location<'static>>>,
+        ThinSlicePtr<'w, UnsafeCell<Location<'static>>>,
     )>,
     // T::STORAGE_TYPE = StorageType::SparseSet
     sparse_set: Option<&'w ComponentSparseSet>,

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1026,7 +1026,7 @@ pub struct RefFetch<'w, T> {
         ThinSlicePtr<'w, UnsafeCell<T>>,
         ThinSlicePtr<'w, UnsafeCell<Tick>>,
         ThinSlicePtr<'w, UnsafeCell<Tick>>,
-        ThinSlicePtr<'w, UnsafeCell<Location<'static>>>,
+        ThinSlicePtr<'w, UnsafeCell<&'static Location<'static>>>,
     )>,
     // T::STORAGE_TYPE = StorageType::SparseSet
     sparse_set: Option<&'w ComponentSparseSet>,
@@ -1215,7 +1215,7 @@ pub struct WriteFetch<'w, T> {
         ThinSlicePtr<'w, UnsafeCell<T>>,
         ThinSlicePtr<'w, UnsafeCell<Tick>>,
         ThinSlicePtr<'w, UnsafeCell<Tick>>,
-        ThinSlicePtr<'w, UnsafeCell<Location<'static>>>,
+        ThinSlicePtr<'w, UnsafeCell<&'static Location<'static>>>,
     )>,
     // T::STORAGE_TYPE = StorageType::SparseSet
     sparse_set: Option<&'w ComponentSparseSet>,

--- a/crates/bevy_ecs/src/reflect/component.rs
+++ b/crates/bevy_ecs/src/reflect/component.rs
@@ -296,6 +296,7 @@ impl<C: Component + Reflect> FromType<C> for ReflectComponent {
                 entity.into_mut::<C>().map(|c| Mut {
                     value: c.value as &mut dyn Reflect,
                     ticks: c.ticks,
+                    #[cfg(feature = "track_change_detection")]
                     caller: c.caller,
                 })
             },
@@ -306,6 +307,7 @@ impl<C: Component + Reflect> FromType<C> for ReflectComponent {
                     entity.get_mut::<C>().map(|c| Mut {
                         value: c.value as &mut dyn Reflect,
                         ticks: c.ticks,
+                        #[cfg(feature = "track_change_detection")]
                         caller: c.caller,
                     })
                 }

--- a/crates/bevy_ecs/src/reflect/resource.rs
+++ b/crates/bevy_ecs/src/reflect/resource.rs
@@ -207,6 +207,7 @@ impl<R: Resource + FromReflect> FromType<R> for ReflectResource {
                     world.get_resource_mut::<R>().map(|res| Mut {
                         value: res.value as &mut dyn Reflect,
                         ticks: res.ticks,
+                        #[cfg(feature = "track_change_detection")]
                         caller: res.caller,
                     })
                 }

--- a/crates/bevy_ecs/src/storage/resource.rs
+++ b/crates/bevy_ecs/src/storage/resource.rs
@@ -1,8 +1,9 @@
 use crate::archetype::ArchetypeComponentId;
-use crate::change_detection::{MutUntyped, TicksMut};
+use crate::change_detection::{MaybeLocation, MaybeUnsafeCellLocation, MutUntyped, TicksMut};
 use crate::component::{ComponentId, ComponentTicks, Components, Tick, TickCells};
 use crate::storage::{blob_vec::BlobVec, SparseSet};
 use bevy_ptr::{OwningPtr, Ptr, UnsafeCellDeref};
+#[cfg(feature = "track_change_detection")]
 use std::panic::Location;
 use std::{cell::UnsafeCell, mem::ManuallyDrop, thread::ThreadId};
 
@@ -18,6 +19,7 @@ pub struct ResourceData<const SEND: bool> {
     type_name: String,
     id: ArchetypeComponentId,
     origin_thread_id: Option<ThreadId>,
+    #[cfg(feature = "track_change_detection")]
     caller: UnsafeCell<&'static Location<'static>>,
 }
 
@@ -113,11 +115,7 @@ impl<const SEND: bool> ResourceData<SEND> {
     #[inline]
     pub(crate) fn get_with_ticks(
         &self,
-    ) -> Option<(
-        Ptr<'_>,
-        TickCells<'_>,
-        &UnsafeCell<&'static Location<'static>>,
-    )> {
+    ) -> Option<(Ptr<'_>, TickCells<'_>, MaybeUnsafeCellLocation<'_>)> {
         self.is_present().then(|| {
             self.validate_access();
             (
@@ -127,7 +125,10 @@ impl<const SEND: bool> ResourceData<SEND> {
                     added: &self.added_ticks,
                     changed: &self.changed_ticks,
                 },
+                #[cfg(feature = "track_change_detection")]
                 &self.caller,
+                #[cfg(not(feature = "track_change_detection"))]
+                (),
             )
         })
     }
@@ -138,14 +139,15 @@ impl<const SEND: bool> ResourceData<SEND> {
     /// If `SEND` is false, this will panic if a value is present and is not accessed from the
     /// original thread it was inserted in.
     pub(crate) fn get_mut(&mut self, last_run: Tick, this_run: Tick) -> Option<MutUntyped<'_>> {
-        let (ptr, ticks, caller) = self.get_with_ticks()?;
+        let (ptr, ticks, _caller) = self.get_with_ticks()?;
         Some(MutUntyped {
             // SAFETY: We have exclusive access to the underlying storage.
             value: unsafe { ptr.assert_unique() },
             // SAFETY: We have exclusive access to the underlying storage.
             ticks: unsafe { TicksMut::from_tick_cells(ticks, last_run, this_run) },
+            #[cfg(feature = "track_change_detection")]
             // SAFETY: We have exclusive access to the underlying storage.
-            caller: unsafe { caller.deref_mut() },
+            caller: unsafe { _caller.deref_mut() },
         })
     }
 
@@ -218,9 +220,7 @@ impl<const SEND: bool> ResourceData<SEND> {
     /// original thread it was inserted from.
     #[inline]
     #[must_use = "The returned pointer to the removed component should be used or dropped"]
-    pub(crate) fn remove(
-        &mut self,
-    ) -> Option<(OwningPtr<'_>, ComponentTicks, &'static Location<'static>)> {
+    pub(crate) fn remove(&mut self) -> Option<(OwningPtr<'_>, ComponentTicks, MaybeLocation)> {
         if !self.is_present() {
             return None;
         }
@@ -231,7 +231,10 @@ impl<const SEND: bool> ResourceData<SEND> {
         let res = unsafe { self.data.swap_remove_and_forget_unchecked(Self::ROW) };
 
         // SAFETY: This function is being called through an exclusive mutable reference to Self
+        #[cfg(feature = "track_change_detection")]
         let caller = unsafe { *self.caller.deref_mut() };
+        #[cfg(not(feature = "track_change_detection"))]
+        let caller = ();
 
         // SAFETY: This function is being called through an exclusive mutable reference to Self, which
         // makes it sound to read these ticks.
@@ -351,6 +354,7 @@ impl<const SEND: bool> Resources<SEND> {
                 type_name: String::from(component_info.name()),
                 id: f(),
                 origin_thread_id: None,
+                #[cfg(feature = "track_change_detection")]
                 caller: UnsafeCell::new(Location::caller())
             }
         })

--- a/crates/bevy_ecs/src/storage/resource.rs
+++ b/crates/bevy_ecs/src/storage/resource.rs
@@ -18,7 +18,7 @@ pub struct ResourceData<const SEND: bool> {
     type_name: String,
     id: ArchetypeComponentId,
     origin_thread_id: Option<ThreadId>,
-    caller: UnsafeCell<Location<'static>>,
+    caller: UnsafeCell<&'static Location<'static>>,
 }
 
 impl<const SEND: bool> Drop for ResourceData<SEND> {
@@ -113,7 +113,11 @@ impl<const SEND: bool> ResourceData<SEND> {
     #[inline]
     pub(crate) fn get_with_ticks(
         &self,
-    ) -> Option<(Ptr<'_>, TickCells<'_>, &UnsafeCell<Location<'static>>)> {
+    ) -> Option<(
+        Ptr<'_>,
+        TickCells<'_>,
+        &UnsafeCell<&'static Location<'static>>,
+    )> {
         self.is_present().then(|| {
             self.validate_access();
             (
@@ -214,7 +218,9 @@ impl<const SEND: bool> ResourceData<SEND> {
     /// original thread it was inserted from.
     #[inline]
     #[must_use = "The returned pointer to the removed component should be used or dropped"]
-    pub(crate) fn remove(&mut self) -> Option<(OwningPtr<'_>, ComponentTicks, Location<'static>)> {
+    pub(crate) fn remove(
+        &mut self,
+    ) -> Option<(OwningPtr<'_>, ComponentTicks, &'static Location<'static>)> {
         if !self.is_present() {
             return None;
         }
@@ -345,7 +351,7 @@ impl<const SEND: bool> Resources<SEND> {
                 type_name: String::from(component_info.name()),
                 id: f(),
                 origin_thread_id: None,
-                caller: UnsafeCell::new(*Location::caller())
+                caller: UnsafeCell::new(Location::caller())
             }
         })
     }

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use bevy_ptr::{OwningPtr, Ptr};
 use nonmax::NonMaxUsize;
-use std::{cell::UnsafeCell, hash::Hash, marker::PhantomData};
+use std::{cell::UnsafeCell, hash::Hash, marker::PhantomData, panic::Location};
 
 type EntityIndex = u32;
 
@@ -169,7 +169,7 @@ impl ComponentSparseSet {
         entity: Entity,
         value: OwningPtr<'_>,
         change_tick: Tick,
-        caller: core::panic::Location<'static>,
+        caller: Location<'static>,
     ) {
         if let Some(&dense_index) = self.sparse.get(entity.index()) {
             #[cfg(debug_assertions)]
@@ -227,11 +227,7 @@ impl ComponentSparseSet {
     pub fn get_with_ticks(
         &self,
         entity: Entity,
-    ) -> Option<(
-        Ptr<'_>,
-        TickCells<'_>,
-        &UnsafeCell<core::panic::Location<'static>>,
-    )> {
+    ) -> Option<(Ptr<'_>, TickCells<'_>, &UnsafeCell<Location<'static>>)> {
         let dense_index = *self.sparse.get(entity.index())?;
         #[cfg(debug_assertions)]
         assert_eq!(entity, self.entities[dense_index.as_usize()]);

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -169,7 +169,7 @@ impl ComponentSparseSet {
         entity: Entity,
         value: OwningPtr<'_>,
         change_tick: Tick,
-        caller: Location<'static>,
+        caller: &'static Location<'static>,
     ) {
         if let Some(&dense_index) = self.sparse.get(entity.index()) {
             #[cfg(debug_assertions)]
@@ -227,7 +227,11 @@ impl ComponentSparseSet {
     pub fn get_with_ticks(
         &self,
         entity: Entity,
-    ) -> Option<(Ptr<'_>, TickCells<'_>, &UnsafeCell<Location<'static>>)> {
+    ) -> Option<(
+        Ptr<'_>,
+        TickCells<'_>,
+        &UnsafeCell<&'static Location<'static>>,
+    )> {
         let dense_index = *self.sparse.get(entity.index())?;
         #[cfg(debug_assertions)]
         assert_eq!(entity, self.entities[dense_index.as_usize()]);

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -1,11 +1,14 @@
 use crate::{
+    change_detection::MaybeUnsafeCellLocation,
     component::{ComponentId, ComponentInfo, ComponentTicks, Tick, TickCells},
     entity::Entity,
     storage::{Column, TableRow},
 };
 use bevy_ptr::{OwningPtr, Ptr};
 use nonmax::NonMaxUsize;
-use std::{cell::UnsafeCell, hash::Hash, marker::PhantomData, panic::Location};
+#[cfg(feature = "track_change_detection")]
+use std::panic::Location;
+use std::{cell::UnsafeCell, hash::Hash, marker::PhantomData};
 
 type EntityIndex = u32;
 
@@ -169,16 +172,21 @@ impl ComponentSparseSet {
         entity: Entity,
         value: OwningPtr<'_>,
         change_tick: Tick,
-        caller: &'static Location<'static>,
+        #[cfg(feature = "track_change_detection")] caller: &'static Location<'static>,
     ) {
         if let Some(&dense_index) = self.sparse.get(entity.index()) {
             #[cfg(debug_assertions)]
             assert_eq!(entity, self.entities[dense_index.as_usize()]);
+            #[cfg(feature = "track_change_detection")]
             self.dense.replace(dense_index, value, change_tick, caller);
         } else {
             let dense_index = self.dense.len();
-            self.dense
-                .push(value, ComponentTicks::new(change_tick), caller);
+            self.dense.push(
+                value,
+                ComponentTicks::new(change_tick),
+                #[cfg(feature = "track_change_detection")]
+                caller,
+            );
             self.sparse
                 .insert(entity.index(), TableRow::from_usize(dense_index));
             #[cfg(debug_assertions)]
@@ -227,11 +235,7 @@ impl ComponentSparseSet {
     pub fn get_with_ticks(
         &self,
         entity: Entity,
-    ) -> Option<(
-        Ptr<'_>,
-        TickCells<'_>,
-        &UnsafeCell<&'static Location<'static>>,
-    )> {
+    ) -> Option<(Ptr<'_>, TickCells<'_>, MaybeUnsafeCellLocation<'_>)> {
         let dense_index = *self.sparse.get(entity.index())?;
         #[cfg(debug_assertions)]
         assert_eq!(entity, self.entities[dense_index.as_usize()]);
@@ -243,7 +247,10 @@ impl ComponentSparseSet {
                     added: self.dense.get_added_tick_unchecked(dense_index),
                     changed: self.dense.get_changed_tick_unchecked(dense_index),
                 },
+                #[cfg(feature = "track_change_detection")]
                 self.dense.get_caller_unchecked(dense_index),
+                #[cfg(not(feature = "track_change_detection"))]
+                (),
             ))
         }
     }

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -177,8 +177,13 @@ impl ComponentSparseSet {
         if let Some(&dense_index) = self.sparse.get(entity.index()) {
             #[cfg(debug_assertions)]
             assert_eq!(entity, self.entities[dense_index.as_usize()]);
-            #[cfg(feature = "track_change_detection")]
-            self.dense.replace(dense_index, value, change_tick, caller);
+            self.dense.replace(
+                dense_index,
+                value,
+                change_tick,
+                #[cfg(feature = "track_change_detection")]
+                caller,
+            );
         } else {
             let dense_index = self.dense.len();
             self.dense.push(

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -22,6 +22,7 @@ use std::{
     fmt::Debug,
     marker::PhantomData,
     ops::{Deref, DerefMut},
+    panic::Location,
 };
 
 /// A parameter that can be used in a [`System`](super::System).
@@ -1044,7 +1045,7 @@ pub struct NonSend<'w, T: 'static> {
     ticks: ComponentTicks,
     last_run: Tick,
     this_run: Tick,
-    caller: &'w core::panic::Location<'static>,
+    caller: &'w Location<'static>,
 }
 
 // SAFETY: Only reads a single World non-send resource
@@ -1071,7 +1072,7 @@ impl<'w, T: 'static> NonSend<'w, T> {
     }
 
     /// The location that last caused this to change.
-    pub fn changed_by(&self) -> core::panic::Location<'static> {
+    pub fn changed_by(&self) -> Location<'static> {
         *self.caller
     }
 }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -18,11 +18,12 @@ pub use bevy_ecs_macros::Resource;
 pub use bevy_ecs_macros::SystemParam;
 use bevy_ptr::UnsafeCellDeref;
 use bevy_utils::{all_tuples, synccell::SyncCell};
+#[cfg(feature = "track_change_detection")]
+use std::panic::Location;
 use std::{
     fmt::Debug,
     marker::PhantomData,
     ops::{Deref, DerefMut},
-    panic::Location,
 };
 
 /// A parameter that can be used in a [`System`](super::System).
@@ -524,7 +525,7 @@ unsafe impl<'a, T: Resource> SystemParam for Res<'a, T> {
         world: UnsafeWorldCell<'w>,
         change_tick: Tick,
     ) -> Self::Item<'w, 's> {
-        let (ptr, ticks, caller) =
+        let (ptr, ticks, _caller) =
             world
                 .get_resource_with_ticks(component_id)
                 .unwrap_or_else(|| {
@@ -542,7 +543,8 @@ unsafe impl<'a, T: Resource> SystemParam for Res<'a, T> {
                 last_run: system_meta.last_run,
                 this_run: change_tick,
             },
-            caller: caller.deref(),
+            #[cfg(feature = "track_change_detection")]
+            caller: _caller.deref(),
         }
     }
 }
@@ -568,7 +570,7 @@ unsafe impl<'a, T: Resource> SystemParam for Option<Res<'a, T>> {
     ) -> Self::Item<'w, 's> {
         world
             .get_resource_with_ticks(component_id)
-            .map(|(ptr, ticks, caller)| Res {
+            .map(|(ptr, ticks, _caller)| Res {
                 value: ptr.deref(),
                 ticks: Ticks {
                     added: ticks.added.deref(),
@@ -576,7 +578,8 @@ unsafe impl<'a, T: Resource> SystemParam for Option<Res<'a, T>> {
                     last_run: system_meta.last_run,
                     this_run: change_tick,
                 },
-                caller: caller.deref(),
+                #[cfg(feature = "track_change_detection")]
+                caller: _caller.deref(),
             })
     }
 }
@@ -639,6 +642,7 @@ unsafe impl<'a, T: Resource> SystemParam for ResMut<'a, T> {
                 last_run: system_meta.last_run,
                 this_run: change_tick,
             },
+            #[cfg(feature = "track_change_detection")]
             caller: value.caller,
         }
     }
@@ -670,6 +674,7 @@ unsafe impl<'a, T: Resource> SystemParam for Option<ResMut<'a, T>> {
                     last_run: system_meta.last_run,
                     this_run: change_tick,
                 },
+                #[cfg(feature = "track_change_detection")]
                 caller: value.caller,
             })
     }
@@ -1045,6 +1050,7 @@ pub struct NonSend<'w, T: 'static> {
     ticks: ComponentTicks,
     last_run: Tick,
     this_run: Tick,
+    #[cfg(feature = "track_change_detection")]
     caller: &'static Location<'static>,
 }
 
@@ -1072,6 +1078,7 @@ impl<'w, T: 'static> NonSend<'w, T> {
     }
 
     /// The location that last caused this to change.
+    #[cfg(feature = "track_change_detection")]
     pub fn changed_by(&self) -> &'static Location<'static> {
         self.caller
     }
@@ -1094,6 +1101,7 @@ impl<'a, T> From<NonSendMut<'a, T>> for NonSend<'a, T> {
             },
             this_run: nsm.ticks.this_run,
             last_run: nsm.ticks.last_run,
+            #[cfg(feature = "track_change_detection")]
             caller: nsm.caller,
         }
     }
@@ -1139,7 +1147,7 @@ unsafe impl<'a, T: 'static> SystemParam for NonSend<'a, T> {
         world: UnsafeWorldCell<'w>,
         change_tick: Tick,
     ) -> Self::Item<'w, 's> {
-        let (ptr, ticks, caller) =
+        let (ptr, ticks, _caller) =
             world
                 .get_non_send_with_ticks(component_id)
                 .unwrap_or_else(|| {
@@ -1155,7 +1163,8 @@ unsafe impl<'a, T: 'static> SystemParam for NonSend<'a, T> {
             ticks: ticks.read(),
             last_run: system_meta.last_run,
             this_run: change_tick,
-            caller: caller.deref(),
+            #[cfg(feature = "track_change_detection")]
+            caller: _caller.deref(),
         }
     }
 }
@@ -1181,12 +1190,13 @@ unsafe impl<T: 'static> SystemParam for Option<NonSend<'_, T>> {
     ) -> Self::Item<'w, 's> {
         world
             .get_non_send_with_ticks(component_id)
-            .map(|(ptr, ticks, caller)| NonSend {
+            .map(|(ptr, ticks, _caller)| NonSend {
                 value: ptr.deref(),
                 ticks: ticks.read(),
                 last_run: system_meta.last_run,
                 this_run: change_tick,
-                caller: caller.deref(),
+                #[cfg(feature = "track_change_detection")]
+                caller: _caller.deref(),
             })
     }
 }
@@ -1234,7 +1244,7 @@ unsafe impl<'a, T: 'static> SystemParam for NonSendMut<'a, T> {
         world: UnsafeWorldCell<'w>,
         change_tick: Tick,
     ) -> Self::Item<'w, 's> {
-        let (ptr, ticks, caller) =
+        let (ptr, ticks, _caller) =
             world
                 .get_non_send_with_ticks(component_id)
                 .unwrap_or_else(|| {
@@ -1247,7 +1257,8 @@ unsafe impl<'a, T: 'static> SystemParam for NonSendMut<'a, T> {
         NonSendMut {
             value: ptr.assert_unique().deref_mut(),
             ticks: TicksMut::from_tick_cells(ticks, system_meta.last_run, change_tick),
-            caller: caller.deref_mut(),
+            #[cfg(feature = "track_change_detection")]
+            caller: _caller.deref_mut(),
         }
     }
 }
@@ -1270,10 +1281,11 @@ unsafe impl<'a, T: 'static> SystemParam for Option<NonSendMut<'a, T>> {
     ) -> Self::Item<'w, 's> {
         world
             .get_non_send_with_ticks(component_id)
-            .map(|(ptr, ticks, caller)| NonSendMut {
+            .map(|(ptr, ticks, _caller)| NonSendMut {
                 value: ptr.assert_unique().deref_mut(),
                 ticks: TicksMut::from_tick_cells(ticks, system_meta.last_run, change_tick),
-                caller: caller.deref_mut(),
+                #[cfg(feature = "track_change_detection")]
+                caller: _caller.deref_mut(),
             })
     }
 }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1045,7 +1045,7 @@ pub struct NonSend<'w, T: 'static> {
     ticks: ComponentTicks,
     last_run: Tick,
     this_run: Tick,
-    caller: &'w Location<'static>,
+    caller: &'static Location<'static>,
 }
 
 // SAFETY: Only reads a single World non-send resource
@@ -1072,8 +1072,8 @@ impl<'w, T: 'static> NonSend<'w, T> {
     }
 
     /// The location that last caused this to change.
-    pub fn changed_by(&self) -> Location<'static> {
-        *self.caller
+    pub fn changed_by(&self) -> &'static Location<'static> {
+        self.caller
     }
 }
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -960,7 +960,7 @@ impl World {
         let entity_location = {
             let mut bundle_spawner = BundleSpawner::new::<B>(self, change_tick);
             // SAFETY: bundle's type matches `bundle_info`, entity is allocated but non-existent
-            unsafe { bundle_spawner.spawn_non_existent(entity, bundle, *Location::caller()) }
+            unsafe { bundle_spawner.spawn_non_existent(entity, bundle, Location::caller()) }
         };
 
         // SAFETY: entity and location are valid, as they were just created above
@@ -1796,13 +1796,13 @@ impl World {
                 AllocAtWithoutReplacement::DidNotExist => {
                     if let SpawnOrInsert::Spawn(ref mut spawner) = spawn_or_insert {
                         // SAFETY: `entity` is allocated (but non existent), bundle matches inserter
-                        unsafe { spawner.spawn_non_existent(entity, bundle, *Location::caller()) };
+                        unsafe { spawner.spawn_non_existent(entity, bundle, Location::caller()) };
                     } else {
                         // SAFETY: we initialized this bundle_id in `init_info`
                         let mut spawner =
                             unsafe { BundleSpawner::new_with_id(self, bundle_id, change_tick) };
                         // SAFETY: `entity` is valid, `location` matches entity, bundle matches inserter
-                        unsafe { spawner.spawn_non_existent(entity, bundle, *Location::caller()) };
+                        unsafe { spawner.spawn_non_existent(entity, bundle, Location::caller()) };
                         spawn_or_insert = SpawnOrInsert::Spawn(spawner);
                     }
                 }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -41,6 +41,7 @@ use std::{
     any::TypeId,
     fmt,
     mem::MaybeUninit,
+    panic::Location,
     sync::atomic::{AtomicU32, Ordering},
 };
 mod identifier;
@@ -959,9 +960,7 @@ impl World {
         let entity_location = {
             let mut bundle_spawner = BundleSpawner::new::<B>(self, change_tick);
             // SAFETY: bundle's type matches `bundle_info`, entity is allocated but non-existent
-            unsafe {
-                bundle_spawner.spawn_non_existent(entity, bundle, *core::panic::Location::caller())
-            }
+            unsafe { bundle_spawner.spawn_non_existent(entity, bundle, *Location::caller()) }
         };
 
         // SAFETY: entity and location are valid, as they were just created above
@@ -1797,25 +1796,13 @@ impl World {
                 AllocAtWithoutReplacement::DidNotExist => {
                     if let SpawnOrInsert::Spawn(ref mut spawner) = spawn_or_insert {
                         // SAFETY: `entity` is allocated (but non existent), bundle matches inserter
-                        unsafe {
-                            spawner.spawn_non_existent(
-                                entity,
-                                bundle,
-                                *core::panic::Location::caller(),
-                            )
-                        };
+                        unsafe { spawner.spawn_non_existent(entity, bundle, *Location::caller()) };
                     } else {
                         // SAFETY: we initialized this bundle_id in `init_info`
                         let mut spawner =
                             unsafe { BundleSpawner::new_with_id(self, bundle_id, change_tick) };
                         // SAFETY: `entity` is valid, `location` matches entity, bundle matches inserter
-                        unsafe {
-                            spawner.spawn_non_existent(
-                                entity,
-                                bundle,
-                                *core::panic::Location::caller(),
-                            )
-                        };
+                        unsafe { spawner.spawn_non_existent(entity, bundle, *Location::caller()) };
                         spawn_or_insert = SpawnOrInsert::Spawn(spawner);
                     }
                 }

--- a/crates/bevy_ecs/src/world/spawn_batch.rs
+++ b/crates/bevy_ecs/src/world/spawn_batch.rs
@@ -3,7 +3,7 @@ use crate::{
     entity::Entity,
     world::World,
 };
-use std::iter::FusedIterator;
+use std::{iter::FusedIterator, panic::Location};
 
 /// An iterator that spawns a series of entities and returns the [ID](Entity) of
 /// each spawned entity.
@@ -16,7 +16,7 @@ where
 {
     inner: I,
     spawner: BundleSpawner<'w>,
-    caller: core::panic::Location<'static>,
+    caller: Location<'static>,
 }
 
 impl<'w, I> SpawnBatchIter<'w, I>
@@ -43,7 +43,7 @@ where
         Self {
             inner: iter,
             spawner,
-            caller: *core::panic::Location::caller(),
+            caller: *Location::caller(),
         }
     }
 }

--- a/crates/bevy_ecs/src/world/spawn_batch.rs
+++ b/crates/bevy_ecs/src/world/spawn_batch.rs
@@ -16,7 +16,7 @@ where
 {
     inner: I,
     spawner: BundleSpawner<'w>,
-    caller: Location<'static>,
+    caller: &'static Location<'static>,
 }
 
 impl<'w, I> SpawnBatchIter<'w, I>
@@ -43,7 +43,7 @@ where
         Self {
             inner: iter,
             spawner,
-            caller: *Location::caller(),
+            caller: Location::caller(),
         }
     }
 }

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -538,7 +538,11 @@ impl<'w> UnsafeWorldCell<'w> {
     pub(crate) unsafe fn get_resource_with_ticks(
         self,
         component_id: ComponentId,
-    ) -> Option<(Ptr<'w>, TickCells<'w>, &'w UnsafeCell<Location<'static>>)> {
+    ) -> Option<(
+        Ptr<'w>,
+        TickCells<'w>,
+        &'w UnsafeCell<&'static Location<'static>>,
+    )> {
         // SAFETY:
         // - caller ensures there is no `&mut World`
         // - caller ensures there are no mutable borrows of this resource
@@ -562,7 +566,11 @@ impl<'w> UnsafeWorldCell<'w> {
     pub(crate) unsafe fn get_non_send_with_ticks(
         self,
         component_id: ComponentId,
-    ) -> Option<(Ptr<'w>, TickCells<'w>, &'w UnsafeCell<Location<'static>>)> {
+    ) -> Option<(
+        Ptr<'w>,
+        TickCells<'w>,
+        &'w UnsafeCell<&'static Location<'static>>,
+    )> {
         // SAFETY:
         // - caller ensures there is no `&mut World`
         // - caller ensures there are no mutable borrows of this resource
@@ -972,7 +980,11 @@ unsafe fn get_component_and_ticks(
     storage_type: StorageType,
     entity: Entity,
     location: EntityLocation,
-) -> Option<(Ptr<'_>, TickCells<'_>, &UnsafeCell<Location<'static>>)> {
+) -> Option<(
+    Ptr<'_>,
+    TickCells<'_>,
+    &UnsafeCell<&'static Location<'static>>,
+)> {
     match storage_type {
         StorageType::Table => {
             let components = world.fetch_table(location, component_id)?;

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -6,7 +6,7 @@ use super::{Mut, Ref, World, WorldId};
 use crate::{
     archetype::{Archetype, Archetypes},
     bundle::Bundles,
-    change_detection::{MutUntyped, Ticks, TicksMut},
+    change_detection::{MaybeUnsafeCellLocation, MutUntyped, Ticks, TicksMut},
     component::{ComponentId, ComponentTicks, Components, StorageType, Tick, TickCells},
     entity::{Entities, Entity, EntityLocation},
     prelude::Component,
@@ -15,8 +15,10 @@ use crate::{
     system::{Res, Resource},
     world::RawCommandQueue,
 };
-use bevy_ptr::{Ptr, UnsafeCellDeref};
-use std::{any::TypeId, cell::UnsafeCell, fmt::Debug, marker::PhantomData, panic::Location, ptr};
+use bevy_ptr::Ptr;
+#[cfg(feature = "track_change_detection")]
+use bevy_ptr::UnsafeCellDeref;
+use std::{any::TypeId, cell::UnsafeCell, fmt::Debug, marker::PhantomData, ptr};
 
 /// Variant of the [`World`] where resource and component accesses take `&self`, and the responsibility to avoid
 /// aliasing violations are given to the caller instead of being checked at compile-time by rust's unique XOR shared rule.
@@ -323,7 +325,7 @@ impl<'w> UnsafeWorldCell<'w> {
 
         // SAFETY: caller ensures `self` has permission to access the resource
         // caller also ensure that no mutable reference to the resource exists
-        let (ptr, ticks, caller) = unsafe { self.get_resource_with_ticks(component_id)? };
+        let (ptr, ticks, _caller) = unsafe { self.get_resource_with_ticks(component_id)? };
 
         // SAFETY: `component_id` was obtained from the type ID of `R`
         let value = unsafe { ptr.deref::<R>() };
@@ -333,11 +335,13 @@ impl<'w> UnsafeWorldCell<'w> {
             unsafe { Ticks::from_tick_cells(ticks, self.last_change_tick(), self.change_tick()) };
 
         // SAFETY: caller ensures that no mutable reference to the resource exists
-        let caller = unsafe { caller.deref() };
+        #[cfg(feature = "track_change_detection")]
+        let caller = unsafe { _caller.deref() };
 
         Some(Res {
             value,
             ticks,
+            #[cfg(feature = "track_change_detection")]
             caller,
         })
     }
@@ -442,7 +446,7 @@ impl<'w> UnsafeWorldCell<'w> {
     ) -> Option<MutUntyped<'w>> {
         // SAFETY: we only access data that the caller has ensured is unaliased and `self`
         //  has permission to access.
-        let (ptr, ticks, caller) = unsafe { self.storages() }
+        let (ptr, ticks, _caller) = unsafe { self.storages() }
             .resources
             .get(component_id)?
             .get_with_ticks()?;
@@ -460,10 +464,11 @@ impl<'w> UnsafeWorldCell<'w> {
             // - caller ensures that the resource is unaliased
             value: unsafe { ptr.assert_unique() },
             ticks,
+            #[cfg(feature = "track_change_detection")]
             // SAFETY:
             // - caller ensures that `self` has permission to access the resource
             // - caller ensures that the resource is unaliased
-            caller: unsafe { caller.deref_mut() },
+            caller: unsafe { _caller.deref_mut() },
         })
     }
 
@@ -508,7 +513,7 @@ impl<'w> UnsafeWorldCell<'w> {
         let change_tick = self.change_tick();
         // SAFETY: we only access data that the caller has ensured is unaliased and `self`
         //  has permission to access.
-        let (ptr, ticks, caller) = unsafe { self.storages() }
+        let (ptr, ticks, _caller) = unsafe { self.storages() }
             .non_send_resources
             .get(component_id)?
             .get_with_ticks()?;
@@ -523,8 +528,9 @@ impl<'w> UnsafeWorldCell<'w> {
             // SAFETY: This function has exclusive access to the world so nothing aliases `ptr`.
             value: unsafe { ptr.assert_unique() },
             ticks,
+            #[cfg(feature = "track_change_detection")]
             // SAFETY: This function has exclusive access to the world
-            caller: unsafe { caller.deref_mut() },
+            caller: unsafe { _caller.deref_mut() },
         })
     }
 
@@ -538,11 +544,7 @@ impl<'w> UnsafeWorldCell<'w> {
     pub(crate) unsafe fn get_resource_with_ticks(
         self,
         component_id: ComponentId,
-    ) -> Option<(
-        Ptr<'w>,
-        TickCells<'w>,
-        &'w UnsafeCell<&'static Location<'static>>,
-    )> {
+    ) -> Option<(Ptr<'w>, TickCells<'w>, MaybeUnsafeCellLocation<'w>)> {
         // SAFETY:
         // - caller ensures there is no `&mut World`
         // - caller ensures there are no mutable borrows of this resource
@@ -566,11 +568,7 @@ impl<'w> UnsafeWorldCell<'w> {
     pub(crate) unsafe fn get_non_send_with_ticks(
         self,
         component_id: ComponentId,
-    ) -> Option<(
-        Ptr<'w>,
-        TickCells<'w>,
-        &'w UnsafeCell<&'static Location<'static>>,
-    )> {
+    ) -> Option<(Ptr<'w>, TickCells<'w>, MaybeUnsafeCellLocation<'w>)> {
         // SAFETY:
         // - caller ensures there is no `&mut World`
         // - caller ensures there are no mutable borrows of this resource
@@ -734,11 +732,12 @@ impl<'w> UnsafeEntityCell<'w> {
                 self.entity,
                 self.location,
             )
-            .map(|(value, cells, caller)| Ref {
+            .map(|(value, cells, _caller)| Ref {
                 // SAFETY: returned component is of type T
                 value: value.deref::<T>(),
                 ticks: Ticks::from_tick_cells(cells, last_change_tick, change_tick),
-                caller: caller.deref(),
+                #[cfg(feature = "track_change_detection")]
+                caller: _caller.deref(),
             })
         }
     }
@@ -834,11 +833,12 @@ impl<'w> UnsafeEntityCell<'w> {
                 self.entity,
                 self.location,
             )
-            .map(|(value, cells, caller)| Mut {
+            .map(|(value, cells, _caller)| Mut {
                 // SAFETY: returned component is of type T
                 value: value.assert_unique().deref_mut::<T>(),
                 ticks: TicksMut::from_tick_cells(cells, last_change_tick, change_tick),
-                caller: caller.deref_mut(),
+                #[cfg(feature = "track_change_detection")]
+                caller: _caller.deref_mut(),
             })
         }
     }
@@ -895,7 +895,7 @@ impl<'w> UnsafeEntityCell<'w> {
                 self.entity,
                 self.location,
             )
-            .map(|(value, cells, caller)| MutUntyped {
+            .map(|(value, cells, _caller)| MutUntyped {
                 // SAFETY: world access validated by caller and ties world lifetime to `MutUntyped` lifetime
                 value: value.assert_unique(),
                 ticks: TicksMut::from_tick_cells(
@@ -903,7 +903,8 @@ impl<'w> UnsafeEntityCell<'w> {
                     self.world.last_change_tick(),
                     self.world.change_tick(),
                 ),
-                caller: caller.deref_mut(),
+                #[cfg(feature = "track_change_detection")]
+                caller: _caller.deref_mut(),
             })
         }
     }
@@ -980,11 +981,7 @@ unsafe fn get_component_and_ticks(
     storage_type: StorageType,
     entity: Entity,
     location: EntityLocation,
-) -> Option<(
-    Ptr<'_>,
-    TickCells<'_>,
-    &UnsafeCell<&'static Location<'static>>,
-)> {
+) -> Option<(Ptr<'_>, TickCells<'_>, MaybeUnsafeCellLocation<'_>)> {
     match storage_type {
         StorageType::Table => {
             let components = world.fetch_table(location, component_id)?;
@@ -996,7 +993,10 @@ unsafe fn get_component_and_ticks(
                     added: components.get_added_tick_unchecked(location.table_row),
                     changed: components.get_changed_tick_unchecked(location.table_row),
                 },
+                #[cfg(feature = "track_change_detection")]
                 components.get_caller_unchecked(location.table_row),
+                #[cfg(not(feature = "track_change_detection"))]
+                (),
             ))
         }
         StorageType::SparseSet => world.fetch_sparse_set(component_id)?.get_with_ticks(entity),

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -16,7 +16,7 @@ use crate::{
     world::RawCommandQueue,
 };
 use bevy_ptr::{Ptr, UnsafeCellDeref};
-use std::{any::TypeId, cell::UnsafeCell, fmt::Debug, marker::PhantomData, ptr};
+use std::{any::TypeId, cell::UnsafeCell, fmt::Debug, marker::PhantomData, panic::Location, ptr};
 
 /// Variant of the [`World`] where resource and component accesses take `&self`, and the responsibility to avoid
 /// aliasing violations are given to the caller instead of being checked at compile-time by rust's unique XOR shared rule.
@@ -538,11 +538,7 @@ impl<'w> UnsafeWorldCell<'w> {
     pub(crate) unsafe fn get_resource_with_ticks(
         self,
         component_id: ComponentId,
-    ) -> Option<(
-        Ptr<'w>,
-        TickCells<'w>,
-        &'w UnsafeCell<core::panic::Location<'static>>,
-    )> {
+    ) -> Option<(Ptr<'w>, TickCells<'w>, &'w UnsafeCell<Location<'static>>)> {
         // SAFETY:
         // - caller ensures there is no `&mut World`
         // - caller ensures there are no mutable borrows of this resource
@@ -566,11 +562,7 @@ impl<'w> UnsafeWorldCell<'w> {
     pub(crate) unsafe fn get_non_send_with_ticks(
         self,
         component_id: ComponentId,
-    ) -> Option<(
-        Ptr<'w>,
-        TickCells<'w>,
-        &'w UnsafeCell<core::panic::Location<'static>>,
-    )> {
+    ) -> Option<(Ptr<'w>, TickCells<'w>, &'w UnsafeCell<Location<'static>>)> {
         // SAFETY:
         // - caller ensures there is no `&mut World`
         // - caller ensures there are no mutable borrows of this resource
@@ -980,11 +972,7 @@ unsafe fn get_component_and_ticks(
     storage_type: StorageType,
     entity: Entity,
     location: EntityLocation,
-) -> Option<(
-    Ptr<'_>,
-    TickCells<'_>,
-    &UnsafeCell<core::panic::Location<'static>>,
-)> {
+) -> Option<(Ptr<'_>, TickCells<'_>, &UnsafeCell<Location<'static>>)> {
     match storage_type {
         StorageType::Table => {
             let components = world.fetch_table(location, component_id)?;

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -186,6 +186,9 @@ ios_simulator = ["bevy_pbr?/ios_simulator", "bevy_render?/ios_simulator"]
 # Enable built in global state machines
 bevy_state = ["dep:bevy_state"]
 
+# Enables source location tracking for change detection, which can assist with debugging
+track_change_detection = ["bevy_ecs/track_change_detection"]
+
 [dependencies]
 # bevy
 bevy_a11y = { path = "../bevy_a11y", version = "0.14.0-dev" }

--- a/examples/ecs/component_change_detection.rs
+++ b/examples/ecs/component_change_detection.rs
@@ -40,11 +40,25 @@ fn change_component(time: Res<Time>, mut query: Query<(Entity, &mut MyComponent)
 // Only entities matching the filters will be in the query
 fn change_detection(query: Query<(Entity, Ref<MyComponent>), Changed<MyComponent>>) {
     for (entity, component) in &query {
+        // By default you can only what component was changed on each entity. This is useful, but
+        // what if you have multiple systems modifying the same component?
+        #[cfg(not(feature = "track_change_detection"))]
         info!(
-            "{:?} changed: {:?} by: {}",
+            "{:?} changed {:?}",
             entity,
             component,
-            component.changed_by()
+        );
+
+        // If you enable the `track_change_detection` feature, you can unlock the
+        // `Ref::changed_by()` method. It returns the `Location`, the file and line number, that
+        // the component was changed in. It's not recommended for released games, but great for
+        // debugging!
+        #[cfg(feature = "track_change_detection")]
+        info!(
+            "{:?} changed {:?} in {}",
+            entity,
+            component,
+            component.changed_by(),
         );
     }
 }


### PR DESCRIPTION
Hi! These changes should help https://github.com/bevyengine/bevy/pull/14034 get approved and merged :)

- [x] Imports `Location` instead of typing `core::panic::Location` each time.
- [x] Stores `Location` as a static reference, which decreases the size from 128 to 64 bits.
  - Since it's likely only going to be read once, the performance from dereferencing this pointer is negligible.
- [x] Puts all tracking behind the feature flag `change_detection_source`, which definitely needs a better name.